### PR TITLE
add results data

### DIFF
--- a/src/domains/vocabularies/VocabularyPage.test.tsx
+++ b/src/domains/vocabularies/VocabularyPage.test.tsx
@@ -124,7 +124,6 @@ it('words creator should still attempt words creation if user actively pressed "
 
 function setup() {
   cleanup();
-  vi.restoreAllMocks();
 
   const userInteraction = userEvent.setup();
 

--- a/src/domains/vocabularies/VocabularyPage.tsx
+++ b/src/domains/vocabularies/VocabularyPage.tsx
@@ -105,8 +105,8 @@ export const VocabularyPage: Component = () => {
     await updateVocabularyItems(...updatedWords);
   }
 
-  function testVocabulary() {
-    navigateToVocabularyTest(vocabularyId, navigate);
+  function testVocabulary(config: { useSavedProgress: boolean }) {
+    navigateToVocabularyTest(vocabularyId, navigate, config);
   }
 
   function testSelected() {
@@ -164,7 +164,7 @@ export const VocabularyPage: Component = () => {
           </SheetContent>
         </Sheet>
 
-        <div>
+        <div class="min-w-56 sm:max-w-72 md:min-w-64">
           <BackLink class="mb-4">Back to vocabularies</BackLink>
           <Show when={vocabulary()}>
             {v => (
@@ -182,7 +182,7 @@ export const VocabularyPage: Component = () => {
             )}
           </Show>
 
-          <div class="mt-8 flex flex-wrap gap-4">
+          <div class="mt-8 flex flex-col gap-4">
             <Button
               class="grow"
               size="sm"
@@ -190,15 +190,32 @@ export const VocabularyPage: Component = () => {
             >
               <HiOutlinePlus size={16} /> Add words
             </Button>
-            <Button
-              class="grow"
-              size="sm"
-              variant="secondary"
-              onClick={testVocabulary}
-            >
-              <HiOutlineAcademicCap />
-              Test
-            </Button>
+            <div class="flex flex-wrap gap-4">
+              <Button
+                class="grow"
+                size="sm"
+                variant={
+                  vocabulary()?.hasSavedProgress
+                    ? 'secondary'
+                    : 'defaultOutline'
+                }
+                onClick={() => testVocabulary({ useSavedProgress: false })}
+              >
+                <HiOutlineAcademicCap />
+                Test
+              </Button>
+              <Show when={vocabulary()?.hasSavedProgress}>
+                <Button
+                  class="grow"
+                  size="sm"
+                  variant="defaultOutline"
+                  onClick={() => testVocabulary({ useSavedProgress: true })}
+                >
+                  <HiOutlineAcademicCap />
+                  Continue test
+                </Button>
+              </Show>
+            </div>
           </div>
         </div>
 

--- a/src/domains/vocabularies/VocabularyPage.tsx
+++ b/src/domains/vocabularies/VocabularyPage.tsx
@@ -195,16 +195,14 @@ export const VocabularyPage: Component = () => {
                 class="grow"
                 size="sm"
                 variant={
-                  vocabulary()?.hasSavedProgress
-                    ? 'secondary'
-                    : 'defaultOutline'
+                  vocabulary()?.savedProgress ? 'secondary' : 'defaultOutline'
                 }
                 onClick={() => testVocabulary({ useSavedProgress: false })}
               >
                 <HiOutlineAcademicCap />
                 Test
               </Button>
-              <Show when={vocabulary()?.hasSavedProgress}>
+              <Show when={vocabulary()?.savedProgress}>
                 <Button
                   class="grow"
                   size="sm"

--- a/src/domains/vocabularies/components/VocabularyCard.tsx
+++ b/src/domains/vocabularies/components/VocabularyCard.tsx
@@ -70,7 +70,7 @@ export const VocabularyCard: Component<Props> = props => {
         class="mt-auto p-4 pt-0 flex gap-2 justify-end"
         onClick={e => e.stopPropagation()}
       >
-        <Show when={props.vocabulary.hasSavedProgress}>
+        <Show when={props.vocabulary.savedProgress}>
           <Button
             size="sm"
             variant="secondary"

--- a/src/domains/vocabularies/model/vocabulary-model.ts
+++ b/src/domains/vocabularies/model/vocabulary-model.ts
@@ -1,4 +1,5 @@
 import type { CountryCode } from '~/components/country-select/countries';
+import type { TestResult } from '~/domains/vocabulary-results/model/test-result-model';
 
 export interface VocabularyItem {
   id: number;
@@ -15,5 +16,5 @@ export interface Vocabulary {
   name: string;
   updatedAt: Date;
   vocabularyItems: VocabularyItem[];
-  hasSavedProgress: boolean;
+  savedProgress?: TestResult;
 }

--- a/src/domains/vocabularies/resources/vocabularies-resource.ts
+++ b/src/domains/vocabularies/resources/vocabularies-resource.ts
@@ -7,21 +7,25 @@ import type {
   VocabularyToCreateDB,
 } from './vocabulary-api';
 import { transformToVocabulary } from './vocabulary-transform';
-import { fetchVocabularyProgress } from './vocabulary-progress-api';
 import type { RealOmit } from '../../../util/object';
 import type { VocabularyItemToCreate } from './vocabulary-resource';
+import type { VocabularyProgressApi } from './vocabulary-progress-api';
 
 export type VocabularyToCreate = RealOmit<
   Vocabulary,
-  'id' | 'hasSavedProgress' | 'updatedAt' | 'vocabularyItems'
+  'id' | 'savedProgress' | 'updatedAt' | 'vocabularyItems'
 > & { vocabularyItems: VocabularyItemToCreate[] };
 
 let api: VocabularyApi;
+let progressApi: VocabularyProgressApi;
 let vocabulariesSignal: Signal<boolean>;
 let vocabulariesResource: ResourceReturn<Vocabulary[] | undefined>;
 
-export const initVocabulariesResource = (vocabularyApi: VocabularyApi) => {
-  api = vocabularyApi;
+export const initVocabulariesResource = (apis: {
+  vocabularyApi: VocabularyApi;
+  vocabularyProgressApi: VocabularyProgressApi;
+}) => {
+  ({ vocabularyApi: api, vocabularyProgressApi: progressApi } = apis);
   vocabulariesSignal = createSignal(false);
   vocabulariesResource = createResource(
     vocabulariesSignal[0],
@@ -75,8 +79,8 @@ const transformToVocabularies = async (vocabulariesDB: VocabularyDB[]) => {
 
   // TODO: This is only temporary and should be ultimately saved in DB
   for (const vocabulary of vocabularies) {
-    const progress = await fetchVocabularyProgress(vocabulary.id);
-    vocabulary.hasSavedProgress = Boolean(progress);
+    const progress = await progressApi.fetchVocabularyProgress(vocabulary.id);
+    vocabulary.savedProgress = progress;
   }
 
   return vocabularies;

--- a/src/domains/vocabularies/resources/vocabulary-progress-api.ts
+++ b/src/domains/vocabularies/resources/vocabulary-progress-api.ts
@@ -2,15 +2,15 @@ import { get, set } from 'idb-keyval';
 import type { TestResult } from '~/domains/vocabulary-results/model/test-result-model';
 import type { RealOmit } from '~/util/object';
 
-export const deleteVocabularyProgress = async (vocabularyId: number) => {
+const deleteVocabularyProgress = async (vocabularyId: number) => {
   await set(`vocabulary.${vocabularyId}.progress`, undefined);
 };
 
-export const fetchVocabularyProgress = async (vocabularyId: number) => {
+const fetchVocabularyProgress = async (vocabularyId: number) => {
   return await get<TestResult>(`vocabulary.${vocabularyId}.progress`);
 };
 
-export const saveVocabularyProgress = async (
+const saveVocabularyProgress = async (
   testResult: RealOmit<TestResult, 'updatedAt'>
 ) => {
   await set(
@@ -18,3 +18,11 @@ export const saveVocabularyProgress = async (
     JSON.parse(JSON.stringify(testResult))
   );
 };
+
+export const vocabularyProgressApi = {
+  deleteVocabularyProgress,
+  fetchVocabularyProgress,
+  saveVocabularyProgress,
+};
+
+export type VocabularyProgressApi = typeof vocabularyProgressApi;

--- a/src/domains/vocabularies/resources/vocabulary-progress-api.ts
+++ b/src/domains/vocabularies/resources/vocabulary-progress-api.ts
@@ -1,17 +1,20 @@
-import { get, set } from "idb-keyval";
-import type { SavedProgress } from "~/domains/vocabulary-testing/vocabulary-testing-model";
+import { get, set } from 'idb-keyval';
+import type { TestResult } from '~/domains/vocabulary-results/model/test-result-model';
+import type { RealOmit } from '~/util/object';
 
 export const deleteVocabularyProgress = async (vocabularyId: number) => {
   await set(`vocabulary.${vocabularyId}.progress`, undefined);
-}
+};
 
 export const fetchVocabularyProgress = async (vocabularyId: number) => {
-  return await get<SavedProgress>(`vocabulary.${vocabularyId}.progress`);
+  return await get<TestResult>(`vocabulary.${vocabularyId}.progress`);
 };
 
 export const saveVocabularyProgress = async (
-  vocabularyId: number,
-  progress: SavedProgress
+  testResult: RealOmit<TestResult, 'updatedAt'>
 ) => {
-  await set(`vocabulary.${vocabularyId}.progress`, JSON.parse(JSON.stringify(progress)));
+  await set(
+    `vocabulary.${testResult.vocabularyId}.progress`,
+    JSON.parse(JSON.stringify(testResult))
+  );
 };

--- a/src/domains/vocabularies/resources/vocabulary-resource.ts
+++ b/src/domains/vocabularies/resources/vocabulary-resource.ts
@@ -155,7 +155,7 @@ export const deleteVocabularyProgress = async (vocabularyId: number) => {
   const { mutate } = vocabularyResource[1];
   mutate(v => ({
     ...v!,
-    hasSavedProgress: false,
+    savedProgress: undefined,
   }));
 };
 

--- a/src/domains/vocabularies/resources/vocabulary-transform.ts
+++ b/src/domains/vocabularies/resources/vocabulary-transform.ts
@@ -5,7 +5,7 @@ export const transformToVocabulary = (vocabulary: VocabularyDB): Vocabulary => {
   return {
     id: vocabulary.id,
     country: vocabulary.country,
-    hasSavedProgress: false,
+    savedProgress: undefined,
     name: vocabulary.name,
     updatedAt: new Date(vocabulary.updated_at),
     vocabularyItems: vocabulary.vocabulary_items.map(transformToVocabularyItem),

--- a/src/domains/vocabulary-results/model/test-result-model.ts
+++ b/src/domains/vocabulary-results/model/test-result-model.ts
@@ -1,0 +1,13 @@
+export interface TestResult {
+  vocabularyId: number;
+  updatedAt: Date;
+  done: boolean;
+  words: TestResultWord[];
+}
+
+export interface TestResultWord {
+  id: number;
+  done: boolean;
+  invalidAttempts: number;
+  skipped: boolean;
+}

--- a/src/domains/vocabulary-results/resources/test-result-resource.ts
+++ b/src/domains/vocabulary-results/resources/test-result-resource.ts
@@ -1,0 +1,21 @@
+import { get, set } from 'idb-keyval';
+import type { TestResult } from '../model/test-result-model';
+import type { RealOmit } from '~/util/object';
+
+export async function fetchTestResults(vocabularyId: number) {
+  const result = await get<TestResult>(
+    `vocabulary.${vocabularyId}.lastTestResult`
+  );
+
+  return [result];
+}
+
+export async function saveTestResult(
+  testResult: RealOmit<TestResult, 'updatedAt'>
+) {
+  const updatedResult: TestResult = { ...testResult, updatedAt: new Date() };
+  await set(
+    `vocabulary.${testResult.vocabularyId}.lastTestResult`,
+    updatedResult
+  );
+}

--- a/src/domains/vocabulary-testing/VocabularyTestPage.tsx
+++ b/src/domains/vocabulary-testing/VocabularyTestPage.tsx
@@ -104,6 +104,10 @@ export const VocabularyTestPage = () => {
     navigate('/vocabulary');
   }
 
+  function goToVocabulary() {
+    navigate('..');
+  }
+
   function onRepeat() {
     setInitialWords();
     setDone(false);
@@ -160,7 +164,7 @@ export const VocabularyTestPage = () => {
                       onEditWord={onEditWord}
                       onProgress={saveProgress}
                       onRemoveWord={deleteWord}
-                      onStop={goToVocabularies}
+                      onStop={goToVocabulary}
                       onRepeat={onRepeat}
                       onReset={onReset}
                     />

--- a/src/domains/vocabulary-testing/VocabularyTestPage.tsx
+++ b/src/domains/vocabulary-testing/VocabularyTestPage.tsx
@@ -1,27 +1,21 @@
 import { useNavigate, useParams, useSearchParams } from '@solidjs/router';
-import { Show, createEffect, createSignal, onMount } from 'solid-js';
+import { Show, createEffect, createSignal } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import type { VocabularyItem } from '../vocabularies/model/vocabulary-model';
-import {
-  deleteVocabularyProgress,
-  fetchVocabularyProgress,
-} from '../vocabularies/resources/vocabulary-progress-api';
 import { Results } from './components/Results';
 import type { VocabularyTesterSettings } from './components/VocabularySettings';
 import { VocabularySettings } from './components/VocabularySettings';
 import { VocabularyTester } from './components/VocabularyTester';
 import {
   deleteVocabularyItems,
+  deleteVocabularyProgress,
   getVocabularyResource,
   saveVocabularyProgress,
   updateVocabularyAsInteractedWith,
   updateVocabularyItems,
 } from '../vocabularies/resources/vocabulary-resource';
 import { BackLink } from '~/components/BackLink';
-import type {
-  TestResult,
-  TestResultWord,
-} from '../vocabulary-results/model/test-result-model';
+import type { TestResultWord } from '../vocabulary-results/model/test-result-model';
 import { saveTestResult } from '../vocabulary-results/resources/test-result-resource';
 
 export const VocabularyTestPage = () => {
@@ -40,7 +34,6 @@ export const VocabularyTestPage = () => {
     });
   const [words, setWords] = createSignal<VocabularyItem[]>();
   const [results, setResults] = createSignal<TestResultWord[]>();
-  const [savedProgress, setSavedProgress] = createSignal<TestResult>();
   const [done, setDone] = createSignal(false);
 
   createEffect(() => {
@@ -51,16 +44,6 @@ export const VocabularyTestPage = () => {
     }
 
     setInitialWords();
-  });
-
-  onMount(async () => {
-    if (!searchParams.useSavedProgress) {
-      return;
-    }
-
-    // move to the effect above, to handle stale vocabulary
-    const progress = await fetchVocabularyProgress(vocabularyId);
-    setSavedProgress(progress);
   });
 
   function setInitialWords() {
@@ -158,7 +141,11 @@ export const VocabularyTestPage = () => {
                   <main class="m-auto mb-4">
                     <VocabularyTester
                       testSettings={vocabularySettings}
-                      savedProgress={savedProgress()?.words}
+                      savedProgress={
+                        searchParams.useSavedProgress
+                          ? vocabulary()?.savedProgress?.words
+                          : undefined
+                      }
                       words={w()}
                       onDone={onDone}
                       onEditWord={onEditWord}

--- a/src/domains/vocabulary-testing/VocabularyTestPage.tsx
+++ b/src/domains/vocabulary-testing/VocabularyTestPage.tsx
@@ -5,7 +5,6 @@ import type { VocabularyItem } from '../vocabularies/model/vocabulary-model';
 import {
   deleteVocabularyProgress,
   fetchVocabularyProgress,
-  saveVocabularyProgress,
 } from '../vocabularies/resources/vocabulary-progress-api';
 import { Results } from './components/Results';
 import type { VocabularyTesterSettings } from './components/VocabularySettings';
@@ -14,6 +13,7 @@ import { VocabularyTester } from './components/VocabularyTester';
 import {
   deleteVocabularyItems,
   getVocabularyResource,
+  saveVocabularyProgress,
   updateVocabularyAsInteractedWith,
   updateVocabularyItems,
 } from '../vocabularies/resources/vocabulary-resource';

--- a/src/domains/vocabulary-testing/components/Results.tsx
+++ b/src/domains/vocabulary-testing/components/Results.tsx
@@ -5,9 +5,10 @@ import { WordEditorDialog } from '~/domains/vocabularies/components/WordEditorDi
 import type { VocabularyItem } from '~/domains/vocabularies/model/vocabulary-model';
 import { ResultWord } from './ResultWord';
 import { Progress, ProgressValueLabel } from '~/components/ui/progress';
+import type { TestResultWord } from '~/domains/vocabulary-results/model/test-result-model';
 
 interface ResultsProps {
-  invalidWords?: VocabularyItem[];
+  results: TestResultWord[];
   words: VocabularyItem[];
   editWord: (word: VocabularyItem) => void;
   repeat: () => void;
@@ -17,6 +18,11 @@ interface ResultsProps {
 
 export function Results(props: ResultsProps) {
   const [wordToEdit, setWordToEdit] = createSignal<VocabularyItem>();
+
+  const invalidWords = () =>
+    props.results
+      .filter(word => word.invalidAttempts > 0)
+      .map(word => props.words.find(w => w.id === word.id)!);
 
   function onWordEdited(word: VocabularyItem) {
     props.editWord(word);
@@ -37,7 +43,7 @@ export function Results(props: ResultsProps) {
       <Progress
         class="mt-12 mx-auto w-full sm:w-96"
         barColor="#094501"
-        value={props.words.length - (props.invalidWords?.length ?? 0)}
+        value={props.words.length - (invalidWords()?.length ?? 0)}
         maxValue={props.words.length}
         getValueLabel={({ value, max }) =>
           `${value} out of ${max} (${Math.floor(
@@ -50,7 +56,7 @@ export function Results(props: ResultsProps) {
         </div>
       </Progress>
 
-      <Show when={props.invalidWords}>
+      <Show when={invalidWords()}>
         {invalidWords => (
           <section class="mx-auto mt-10 flex flex-col">
             <h2 class="mb-4 text-lg text-center">
@@ -79,7 +85,7 @@ export function Results(props: ResultsProps) {
       </Show>
 
       <div class="mx-auto mt-8 flex items-center gap-4 sm:mt-16">
-        <Show when={props.invalidWords}>
+        <Show when={invalidWords()}>
           {invalidWords => (
             <Button
               class="btn-link"

--- a/src/domains/vocabulary-testing/components/Results.tsx
+++ b/src/domains/vocabulary-testing/components/Results.tsx
@@ -57,7 +57,10 @@ export function Results(props: ResultsProps) {
               Words you guessed incorrectly
             </h2>
 
-            <ul class="mx-auto max-h-64 overflow-y-auto">
+            <ul
+              class="mx-auto max-h-64 overflow-y-auto"
+              data-testid="results-invalid-words"
+            >
               <For each={invalidWords()}>
                 {word => (
                   <li>

--- a/src/domains/vocabulary-testing/components/VocabularyTester.tsx
+++ b/src/domains/vocabulary-testing/components/VocabularyTester.tsx
@@ -272,7 +272,7 @@ export const VocabularyTester: Component<TesterProps> = (
 
         {/* mb-[-0.5rem] is here to bypass the vertical flex gap */}
         <div class="mb-[-0.5rem] flex items-center">
-          {toTranslate()}
+          <span data-testid="original-to-translate">{toTranslate()}</span>
           <Show when={currentWord()?.notes}>
             {notes => (
               <Popover>

--- a/src/domains/vocabulary-testing/components/VocabularyTester.tsx
+++ b/src/domains/vocabulary-testing/components/VocabularyTester.tsx
@@ -316,7 +316,7 @@ export const VocabularyTester: Component<TesterProps> = (
             <Button onClick={setNextWord}>Next</Button>
           </Show>
           <Button class="btn-link" variant="outline" onClick={props.onStop}>
-            Stop test
+            Pause test
           </Button>
           <Button class="btn-link" variant="outline" onClick={finish}>
             Finish test

--- a/src/domains/vocabulary-testing/components/VocabularyTester.tsx
+++ b/src/domains/vocabulary-testing/components/VocabularyTester.tsx
@@ -325,7 +325,7 @@ export const VocabularyTester: Component<TesterProps> = (
       </Show>
 
       <Progress
-        aria-label="Words done percentage"
+        aria-label="Words done progress"
         class="my-6 mx-auto w-full sm:mt-20"
         value={percentageDone()}
         getValueLabel={() =>

--- a/src/domains/vocabulary-testing/components/WriteTester.tsx
+++ b/src/domains/vocabulary-testing/components/WriteTester.tsx
@@ -218,7 +218,7 @@ export const WriteTester: Component<WriteTesterProps> = props => {
               aria-label="Next word"
               title="Next word"
               type={isSkipBtnSubmitter() ? 'submit' : 'button'}
-              onClick={props.onSkip}
+              onClick={isSkipBtnSubmitter() ? undefined : props.onSkip}
             >
               <HiOutlineForward
                 class={cx(!valid() && 'opacity-75')}

--- a/src/domains/vocabulary-testing/util/test-util.ts
+++ b/src/domains/vocabulary-testing/util/test-util.ts
@@ -1,0 +1,28 @@
+import type {
+  VocabularyDB,
+  VocabularyItemDB,
+} from '~/domains/vocabularies/resources/vocabulary-api';
+
+export function createMockVocabularyDB(config: {
+  wordAmount: number;
+}): VocabularyDB {
+  const words: VocabularyItemDB[] = Array.from(
+    { length: config.wordAmount },
+    (_, index) => ({
+      id: index,
+      created_at: String(new Date().getTime()),
+      list_id: 1,
+      original: `original${index}`,
+      translation: `translation${index}`,
+      notes: '',
+    })
+  );
+
+  return {
+    id: 1,
+    name: 'Vocabulary title',
+    country: 'cz',
+    vocabulary_items: words,
+    updated_at: new Date(),
+  };
+}

--- a/src/domains/vocabulary-testing/vocabulary-testing-model.ts
+++ b/src/domains/vocabulary-testing/vocabulary-testing-model.ts
@@ -1,6 +1,0 @@
-import type { VocabularyItem } from '../vocabularies/model/vocabulary-model';
-
-export interface SavedProgress {
-  invalidWords: VocabularyItem[];
-  leftOverWords: VocabularyItem[];
-}

--- a/src/init/app-init.ts
+++ b/src/init/app-init.ts
@@ -4,6 +4,8 @@ import {
 } from '~/domains/vocabularies/resources/vocabularies-resource';
 import type { VocabularyApi } from '~/domains/vocabularies/resources/vocabulary-api';
 import { vocabularyApi } from '~/domains/vocabularies/resources/vocabulary-api';
+import type { VocabularyProgressApi } from '~/domains/vocabularies/resources/vocabulary-progress-api';
+import { vocabularyProgressApi } from '~/domains/vocabularies/resources/vocabulary-progress-api';
 import {
   initVocabularyResource,
   resetVocabularyResource,
@@ -11,22 +13,27 @@ import {
 
 export interface ResourcesInit {
   vocabularyApi: VocabularyApi;
+  vocabularyProgressApi: VocabularyProgressApi;
 }
 
 export const initApp = (init?: ResourcesInit) => {
   initResources(
     init ?? {
       vocabularyApi,
+      vocabularyProgressApi,
     }
   );
+};
+
+export const initResources = ({
+  vocabularyApi,
+  vocabularyProgressApi,
+}: ResourcesInit) => {
+  initVocabulariesResource({ vocabularyApi, vocabularyProgressApi });
+  initVocabularyResource({ vocabularyApi, vocabularyProgressApi });
 };
 
 export const resetApp = () => {
   resetVocabulariesResource();
   resetVocabularyResource();
-};
-
-export const initResources = (init: { vocabularyApi: VocabularyApi }) => {
-  initVocabulariesResource(init.vocabularyApi);
-  initVocabularyResource(init.vocabularyApi);
 };

--- a/src/init/test-init.ts
+++ b/src/init/test-init.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import type { ResourcesInit} from './app-init';
+import type { ResourcesInit } from './app-init';
 import { initApp } from './app-init';
 import { createRoot } from 'solid-js';
 
@@ -15,6 +15,11 @@ export const initTestApp = () => {
       fetchRecentVocabularies: vi.fn(),
       updateVocabulary: vi.fn(),
       updateVocabularyItems: vi.fn(),
+    },
+    vocabularyProgressApi: {
+      deleteVocabularyProgress: vi.fn(),
+      fetchVocabularyProgress: vi.fn(),
+      saveVocabularyProgress: vi.fn(),
     },
   } satisfies ResourcesInit;
 

--- a/src/init/test-init.ts
+++ b/src/init/test-init.ts
@@ -1,7 +1,7 @@
+import { createRoot } from 'solid-js';
 import { vi } from 'vitest';
 import type { ResourcesInit } from './app-init';
 import { initApp } from './app-init';
-import { createRoot } from 'solid-js';
 
 export const initTestApp = () => {
   const resources = {


### PR DESCRIPTION
- **test: displaying results after a test**
- **fix: don't call skip when it's no skip at all**
- **add: storing of test results**
- **change: navigation and copy of "Stop test"**
- **add: continue test on vocabulary page**
- **change: fetch vocabulary progress in resource**
- **test: add vocabulary test progress case**

Originally I wanted to include also some UI in this PR already, but in the end I already had so many changes with just the preparation work that I decided go out with it with more or less just the storing mechanism.
